### PR TITLE
Kubernetes Role: Allow more actions on batch/jobs apiGroups

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -79,3 +79,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - list
+  - watch
+  - get


### PR DESCRIPTION
### Description
In this PR, we enable more actions on `batch/jobs` apiGroup for vegeta-operator.

As vegeta attacks translated as Job Resources for Kubernetes, operator needs these permissions to do needed actions on them.

### Changes Introduced
- Allow `get/list/watch/create` action on `/apis/batch/v1/jobs`

### Logs Output
```go
reflector.go:105: Failed to watch *v1.Job: unknown (get jobs.batch)
[..]
reflector.go:105: Failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:vegeta:vegeta-operator" cannot list resource "jobs" in API group "batch" in the namespace "vegeta"
[..]
```

### Testing Environment
- Kubernetes version: 1.15.10
- Vegeta Operator version: 0.0.1 (build from `master` branch as per c66af2bc165dd1826f9fc4702f41168affba9c28)